### PR TITLE
Save masks as native resolution, and detect and correct rotation from exif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# virtual env files
+venv/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/app.py
+++ b/app.py
@@ -48,25 +48,25 @@ else: # for testing
     image_to_annotate = Image.open(DEFAULT_IMAGE)
     image_to_annotate_name = "test_mask.png"
 
-save_mask_filename = Path(mask_dir, image_to_annotate_name)
-
-if st.sidebar.button(f"Mark as 100% background and save"): # set every pixel to 0
-    mask_arr = np.zeros((DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE), dtype=np.uint8)
-    mask_img = Image.fromarray(mask_arr).convert('L')
-    mask_img.save(save_mask_filename)
-    st.sidebar.write(f"Saved {save_mask_filename}")
-
-if st.sidebar.button(f"Mark as 100% target and save"): # set every pixel to 255
-    mask_arr = np.ones((DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE), dtype=np.uint8) * 255
-    mask_img = Image.fromarray(mask_arr).convert('L')
-    mask_img.save(save_mask_filename)
-    st.sidebar.write(f"Saved {save_mask_filename}")
-
 ## compute input image dimensions for later scaling
 try:
     nx, ny, nd = np.array(image_to_annotate).shape
 except: # 1band greyscale
     nx, ny = np.array(image_to_annotate).shape
+
+save_mask_filename = Path(mask_dir, image_to_annotate_name)
+
+if st.sidebar.button(f"Mark as 100% background and save"): # set every pixel to 0
+    mask_arr = np.zeros((nx, ny), dtype=np.uint8)
+    mask_img = Image.fromarray(mask_arr).convert('L')
+    mask_img.save(save_mask_filename)
+    st.sidebar.write(f"Saved {save_mask_filename}")
+
+if st.sidebar.button(f"Mark as 100% target and save"): # set every pixel to 255
+    mask_arr = np.ones((nx, ny), dtype=np.uint8) * 255
+    mask_img = Image.fromarray(mask_arr).convert('L')
+    mask_img.save(save_mask_filename)
+    st.sidebar.write(f"Saved {save_mask_filename}")
 
 # Otherwise draw the mask
 


### PR DESCRIPTION
Great tool, thanks for sharing!

I want to use this tool for creating pairs of images and corresponding binary masks, for example for training UNet models that require images and masks of the same size (horizontal dimensions) and orientation. This PR therefore implements the following changes:

1. the digitized masks are now saved at the same resolution (image dimensions) as the original image
2. the 100% background and 100% target masks are also saved at the same resolution as the input image
3. the program will now read the image's exif information, determine if and how the image is rotated, and corrects accordingly
4. the program now accepts jpegs and tiffs as well as pngs. This is only because my target [modeling suite](https://github.com/Doodleverse/segmentation_gym) (detailed [here](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2022EA002332) - shameless plug!) works with images and masks in jpeg format
5. I added the virtual env (venv) to the .gitignore

no additional dependencies are required. I hope this is helpful!