### PR TITLE
Save masks as native resolution, and small utility to detect and correct rotation from exif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# virtual env files
+venv/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/app.py
+++ b/app.py
@@ -48,25 +48,25 @@ else: # for testing
     image_to_annotate = Image.open(DEFAULT_IMAGE)
     image_to_annotate_name = "test_mask.png"
 
-save_mask_filename = Path(mask_dir, image_to_annotate_name)
-
-if st.sidebar.button(f"Mark as 100% background and save"): # set every pixel to 0
-    mask_arr = np.zeros((DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE), dtype=np.uint8)
-    mask_img = Image.fromarray(mask_arr).convert('L')
-    mask_img.save(save_mask_filename)
-    st.sidebar.write(f"Saved {save_mask_filename}")
-
-if st.sidebar.button(f"Mark as 100% target and save"): # set every pixel to 255
-    mask_arr = np.ones((DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE), dtype=np.uint8) * 255
-    mask_img = Image.fromarray(mask_arr).convert('L')
-    mask_img.save(save_mask_filename)
-    st.sidebar.write(f"Saved {save_mask_filename}")
-
 ## compute input image dimensions for later scaling
 try:
     nx, ny, nd = np.array(image_to_annotate).shape
 except: # 1band greyscale
     nx, ny = np.array(image_to_annotate).shape
+
+save_mask_filename = Path(mask_dir, image_to_annotate_name)
+
+if st.sidebar.button(f"Mark as 100% background and save"): # set every pixel to 0
+    mask_arr = np.zeros((nx, ny), dtype=np.uint8)
+    mask_img = Image.fromarray(mask_arr).convert('L')
+    mask_img.save(save_mask_filename)
+    st.sidebar.write(f"Saved {save_mask_filename}")
+
+if st.sidebar.button(f"Mark as 100% target and save"): # set every pixel to 255
+    mask_arr = np.ones((nx, ny), dtype=np.uint8) * 255
+    mask_img = Image.fromarray(mask_arr).convert('L')
+    mask_img.save(save_mask_filename)
+    st.sidebar.write(f"Saved {save_mask_filename}")
 
 # Otherwise draw the mask
 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import streamlit as st
 import numpy as np
-# exiftags are to check for a rotated image
-from PIL import Image, ExifTags
+from PIL import Image
 from streamlit_drawable_canvas import st_canvas
 from pathlib import Path
 import os
@@ -27,20 +26,6 @@ if mask_dir != DEFAULT_MASKS_DIR:
 
 if uploaded_image: 
     image_to_annotate = Image.open(uploaded_image)
-
-    # detect image orientation
-    for orientation in ExifTags.TAGS.keys():
-        if ExifTags.TAGS[orientation]=='Orientation':
-            break
-    exif=dict(image_to_annotate._getexif().items())
-
-    # if necessary, correct image orientation
-    if exif[orientation] == 3:
-        image_to_annotate=image_to_annotate.rotate(180, expand=True)
-    elif exif[orientation] == 6:
-        image_to_annotate=image_to_annotate.rotate(270, expand=True)
-    elif exif[orientation] == 8:
-        image_to_annotate=image_to_annotate.rotate(90, expand=True)
 
     image_to_annotate_name = uploaded_image.name
     st.text(f"Annotating {image_to_annotate_name}")

--- a/utilities/autorotate_images.py
+++ b/utilities/autorotate_images.py
@@ -1,0 +1,46 @@
+# a simple script to detect and correct rotated images and resave them out to a different folder
+from tkinter import filedialog
+from tkinter import *
+from PIL import Image, ImageDraw, ExifTags
+import os
+
+root = Tk()
+root.filename =  filedialog.askdirectory(initialdir = "./",title = "Select directory of image files")
+image_direc = root.filename
+print(image_direc)
+root.withdraw()
+
+root = Tk()
+root.filename =  filedialog.askdirectory(initialdir = "./",title = "Select output directory")
+out_direc = root.filename
+print(out_direc)
+root.withdraw()
+
+# all_files = []
+for root, dirs, files in os.walk(image_direc, topdown=False):
+
+    ## if you need to rotate images before labeling them on makesense.ai
+    for rawfile in files:
+        try:
+            image = Image.open(root+os.sep+rawfile)
+            for orientation in ExifTags.TAGS.keys():
+                if ExifTags.TAGS[orientation]=='Orientation':
+                    break
+            exif=dict(image._getexif().items())
+
+            if exif[orientation] == 3:
+                image=image.rotate(180, expand=True)
+            elif exif[orientation] == 6:
+                image=image.rotate(270, expand=True)
+            elif exif[orientation] == 8:
+                image=image.rotate(90, expand=True)
+
+            if 'jpg' in rawfile:  
+                image.save(out_direc+os.sep+rawfile, format='JPEG')	
+            else:     
+                image.save(out_direc+os.sep+rawfile, format='PNG')
+
+        except (AttributeError, KeyError, IndexError):
+            # cases: image don't have getexif
+            pass
+                	


### PR DESCRIPTION
Great tool, thanks for sharing!

I want to use this tool for creating pairs of images and corresponding binary masks, for example for training UNet models that require images and masks of the same size (horizontal dimensions) and orientation. This PR therefore implements the following changes:

1. the digitized masks are now saved at the same resolution (image dimensions) as the original image
2. the 100% background and 100% target masks are also saved at the same resolution as the input image
3. the program now accepts jpegs and tiffs as well as pngs. This is only because my target [modeling suite](https://github.com/Doodleverse/segmentation_gym) (detailed [here](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2022EA002332) - shameless plug!) works with images and masks in jpeg format
4. I added the virtual env (venv) to the .gitignore
5. I included a small utility program will now read all images in a folder, read the image's exif information, determine if and how the image is rotated, and corrects accordingly, and resave to a different folder. Alternatively, this could be included in the `app.py` (that's what my original PR did, but I reverted back to a separate script with exception handling)

no additional dependencies are required. I hope this is helpful!